### PR TITLE
feat(core-services): CDK | Add override for desired jumpbox capacity [RDMP-4640]

### DIFF
--- a/API.md
+++ b/API.md
@@ -178,10 +178,13 @@ const jumpBoxProps: JumpBoxProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | Which VPC should the jumpbox be in? |
+| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.desiredCapacity">desiredCapacity</a></code> | <code>number</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.instanceType">instanceType</a></code> | <code>aws-cdk-lib.aws_ec2.InstanceType</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.keyPair">keyPair</a></code> | <code>cdk-ec2-key-pair.KeyPair</code> | You must provide either a keypair or a kmsKey. |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.Key</code> | You must provide either a keypair or a kmsKey. |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.machineImage">machineImage</a></code> | <code>aws-cdk-lib.aws_ec2.IMachineImage</code> | Default to latest Amazon Linux 2022 AMI for ARM64. |
+| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.maxCapacity">maxCapacity</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.minCapacity">minCapacity</a></code> | <code>number</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.role">role</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.securityGroup">securityGroup</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.sshAccess">sshAccess</a></code> | <code>boolean</code> | *No description.* |
@@ -198,6 +201,16 @@ public readonly vpc: IVpc;
 - *Type:* aws-cdk-lib.aws_ec2.IVpc
 
 Which VPC should the jumpbox be in?
+
+---
+
+##### `desiredCapacity`<sup>Optional</sup> <a name="desiredCapacity" id="@time-loop/cdk-jump-box.JumpBoxProps.property.desiredCapacity"></a>
+
+```typescript
+public readonly desiredCapacity: number;
+```
+
+- *Type:* number
 
 ---
 
@@ -259,6 +272,26 @@ public readonly machineImage: IMachineImage;
 - *Default:* MachineImage.latestAmazonLinux({generation:AmazonLinuxGeneration.AMAZON_LINUX_2022,edition:AmazonLinuxEdition.STANDARD,cpuType:AmazonLinuxCpuType.ARM_64})
 
 Default to latest Amazon Linux 2022 AMI for ARM64.
+
+---
+
+##### `maxCapacity`<sup>Optional</sup> <a name="maxCapacity" id="@time-loop/cdk-jump-box.JumpBoxProps.property.maxCapacity"></a>
+
+```typescript
+public readonly maxCapacity: number;
+```
+
+- *Type:* number
+
+---
+
+##### `minCapacity`<sup>Optional</sup> <a name="minCapacity" id="@time-loop/cdk-jump-box.JumpBoxProps.property.minCapacity"></a>
+
+```typescript
+public readonly minCapacity: number;
+```
+
+- *Type:* number
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -178,13 +178,13 @@ const jumpBoxProps: JumpBoxProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | Which VPC should the jumpbox be in? |
-| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.desiredCapacity">desiredCapacity</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.desiredCapacity">desiredCapacity</a></code> | <code>number</code> | the desired capacity of the auto scaling group. |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.instanceType">instanceType</a></code> | <code>aws-cdk-lib.aws_ec2.InstanceType</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.keyPair">keyPair</a></code> | <code>cdk-ec2-key-pair.KeyPair</code> | You must provide either a keypair or a kmsKey. |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.Key</code> | You must provide either a keypair or a kmsKey. |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.machineImage">machineImage</a></code> | <code>aws-cdk-lib.aws_ec2.IMachineImage</code> | Default to latest Amazon Linux 2022 AMI for ARM64. |
-| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.maxCapacity">maxCapacity</a></code> | <code>number</code> | *No description.* |
-| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.minCapacity">minCapacity</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.maxCapacity">maxCapacity</a></code> | <code>number</code> | the maximum capacity of the auto scaling group. |
+| <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.minCapacity">minCapacity</a></code> | <code>number</code> | the minimum capacity of the auto scaling group. |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.role">role</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.securityGroup">securityGroup</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-jump-box.JumpBoxProps.property.sshAccess">sshAccess</a></code> | <code>boolean</code> | *No description.* |
@@ -211,7 +211,9 @@ public readonly desiredCapacity: number;
 ```
 
 - *Type:* number
-- *Default:* undefined - the desired capacity of the auto scaling group
+- *Default:* undefined
+
+the desired capacity of the auto scaling group.
 
 ---
 
@@ -283,7 +285,9 @@ public readonly maxCapacity: number;
 ```
 
 - *Type:* number
-- *Default:* 1 - the maximum capacity of the auto scaling group
+- *Default:* 1
+
+the maximum capacity of the auto scaling group.
 
 ---
 
@@ -294,7 +298,9 @@ public readonly minCapacity: number;
 ```
 
 - *Type:* number
-- *Default:* 0 - the minimum capacity of the auto scaling group
+- *Default:* 0
+
+the minimum capacity of the auto scaling group.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -211,6 +211,7 @@ public readonly desiredCapacity: number;
 ```
 
 - *Type:* number
+- *Default:* undefined - the desired capacity of the auto scaling group
 
 ---
 
@@ -282,6 +283,7 @@ public readonly maxCapacity: number;
 ```
 
 - *Type:* number
+- *Default:* 1 - the maximum capacity of the auto scaling group
 
 ---
 
@@ -292,6 +294,7 @@ public readonly minCapacity: number;
 ```
 
 - *Type:* number
+- *Default:* 0 - the minimum capacity of the auto scaling group
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export class JumpBox extends Construct {
       instanceType,
       keyName: this.keyPair.keyPairName,
       machineImage,
-      desiredCapacity: props.desiredCapacity ?? undefined,
+      desiredCapacity: props.desiredCapacity,
       minCapacity: props.minCapacity ?? 0,
       maxCapacity: props.maxCapacity ?? 1,
       role: this.role,

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,8 +53,17 @@ export interface JumpBoxProps {
    * @default - default subnet selection
    */
   readonly vpcSubnets?: aws_ec2.SubnetSelection;
+  /**
+   * @default undefined - the desired capacity of the auto scaling group
+   */
   readonly desiredCapacity?: number;
+  /**
+   * @default 0 - the minimum capacity of the auto scaling group
+   */
   readonly minCapacity?: number;
+  /**
+   * @default 1 - the maximum capacity of the auto scaling group
+   */
   readonly maxCapacity?: number;
 }
 
@@ -119,7 +128,7 @@ export class JumpBox extends Construct {
       instanceType,
       keyName: this.keyPair.keyPairName,
       machineImage,
-      desiredCapacity: props.desiredCapacity,
+      desiredCapacity: props.desiredCapacity ?? undefined,
       minCapacity: props.minCapacity ?? 0,
       maxCapacity: props.maxCapacity ?? 1,
       role: this.role,

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,15 +54,18 @@ export interface JumpBoxProps {
    */
   readonly vpcSubnets?: aws_ec2.SubnetSelection;
   /**
-   * @default undefined - the desired capacity of the auto scaling group
+   * the desired capacity of the auto scaling group
+   * @default undefined
    */
   readonly desiredCapacity?: number;
   /**
-   * @default 0 - the minimum capacity of the auto scaling group
+   * the minimum capacity of the auto scaling group
+   * @default 0
    */
   readonly minCapacity?: number;
   /**
-   * @default 1 - the maximum capacity of the auto scaling group
+   * the maximum capacity of the auto scaling group
+   * @default 1
    */
   readonly maxCapacity?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,9 @@ export interface JumpBoxProps {
    * @default - default subnet selection
    */
   readonly vpcSubnets?: aws_ec2.SubnetSelection;
+  readonly desiredCapacity?: number;
+  readonly minCapacity?: number;
+  readonly maxCapacity?: number;
 }
 
 /**
@@ -116,8 +119,9 @@ export class JumpBox extends Construct {
       instanceType,
       keyName: this.keyPair.keyPairName,
       machineImage,
-      minCapacity: 0,
-      maxCapacity: 1,
+      desiredCapacity: props.desiredCapacity,
+      minCapacity: props.minCapacity ?? 0,
+      maxCapacity: props.maxCapacity ?? 1,
       role: this.role,
       securityGroup: this.securityGroup,
       signals: aws_autoscaling.Signals.waitForMinCapacity({ timeout: Duration.minutes(45) }),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -98,6 +98,12 @@ describe('JumpBox', () => {
     // it('outputs ProxyEndpoint', () => {
     //   template.hasOutput('ProxyEndpoint', {});
     // });
+    it('AutoScalingGroup has min=1, max=1', () => {
+      template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+        MinSize: 1,
+        MaxSize: 1,
+      });
+    });
   });
   describe('options', () => {
     it('instanceType', () => {
@@ -226,6 +232,22 @@ describe('JumpBox', () => {
             },
           ]),
         });
+      });
+    });
+    it('autoScalingGroupProps', () => {
+      const app = new App();
+      const stack = new Stack(app, name.pascal);
+      new JumpBox(stack, new Namer(['test']), {
+        desiredCapacity: 9,
+        minCapacity: 8,
+        maxCapacity: 10,
+        vpc: new aws_ec2.Vpc(stack, 'Vpc'),
+      });
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+        DesiredCapacity: 9,
+        MinSize: 8,
+        MaxSize: 10,
       });
     });
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -79,7 +79,7 @@ describe('JumpBox', () => {
         InstanceType: 't4g.nano',
       });
     });
-    it.only('machineImage is AmazonLinux2022', () => {
+    it('machineImage is AmazonLinux2022', () => {
       // CDK finds the latest Amazon Linux 2022 AMI
       // by referencing a well known SSM parameter.
       const params = template.findParameters('*', {
@@ -100,8 +100,8 @@ describe('JumpBox', () => {
     // });
     it('AutoScalingGroup has min=1, max=1', () => {
       template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
-        MinSize: 1,
-        MaxSize: 1,
+        MinSize: '0',
+        MaxSize: '1',
       });
     });
   });
@@ -241,13 +241,14 @@ describe('JumpBox', () => {
         desiredCapacity: 9,
         minCapacity: 8,
         maxCapacity: 10,
+        kmsKey: new aws_kms.Key(stack, 'Key'),
         vpc: new aws_ec2.Vpc(stack, 'Vpc'),
       });
       const template = Template.fromStack(stack);
       template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
-        DesiredCapacity: 9,
-        MinSize: 8,
-        MaxSize: 10,
+        DesiredCapacity: '9',
+        MinSize: '8',
+        MaxSize: '10',
       });
     });
   });


### PR DESCRIPTION
The default scaling capacity (min=0, max=1, desired=undefined) is problematic for kafka-cdk:
* kafka jumpboxes require stateful onboarding; shutdown removes that state!
* core service team cannot self-manage in AWS console: staging and prod permissions are restricted