### PR TITLE
fix(core-services): Add linux 2 instance for jumpbox [RDMP-5350]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export class JumpBox extends Construct {
     const machineImage =
       props.machineImage ??
       aws_ec2.MachineImage.latestAmazonLinux({
-        generation: aws_ec2.AmazonLinuxGeneration.AMAZON_LINUX_2022,
+        generation: aws_ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
         edition: aws_ec2.AmazonLinuxEdition.STANDARD,
         cpuType: aws_ec2.AmazonLinuxCpuType.ARM_64,
       });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -92,7 +92,7 @@ describe('JumpBox', () => {
         ImageId: { Ref: paramRef },
       });
       // NOTE: this may evolve over time, but was still true as of aws-cdk-lib v2.75.1
-      expect(params[paramRef].Default).toMatch('/aws/service/ami-amazon-linux-latest/al2022-ami-kernel-5.10-arm64');
+      expect(params[paramRef].Default).toMatch('/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2');
     });
 
     // it('outputs ProxyEndpoint', () => {


### PR DESCRIPTION
Fixes # This tries to help use avoid the replacement of jumpbox instance when rolling kafka cluster.